### PR TITLE
Bæta við auka verification reward

### DIFF
--- a/lobe/settings/common.py
+++ b/lobe/settings/common.py
@@ -141,6 +141,13 @@ ECONOMY = {
                 'coin_reward': 1000,
                 'experience_reward': 10000,
                 'fa_id': 'fa fa-user-astronaut',
+            },
+            '6': {
+                'title': 'Út fyrir endimörk alheimsins',
+                'goal': 30000,
+                'coin_reward': 2000,
+                'experience_reward': 20000,
+                'fa_id': 'fa fa-rocket',
             }
         }, 'spy': {
             '0': {


### PR DESCRIPTION
Það kemur villa eftir að 15000 verifications hafa verið gerð. Auka achievement tier ætti að laga það, en aðal villan er keyError í 
  lobe/views/verification/verification.py", line 316, in create_verification.

            # check for achivement updates:
            # 1. verification:
            verification_info = app.config['ECONOMY']['achievements'][
                'verification'][str(progression.verification_level)]