### PR TITLE
Possible fix for "level 6 verification error"

### DIFF
--- a/lobe/views/verification/verification.py
+++ b/lobe/views/verification/verification.py
@@ -314,14 +314,19 @@ def create_verification():
 
             # check for achivement updates:
             # 1. verification:
-            verification_info = app.config['ECONOMY']['achievements'][
-                'verification'][str(progression.verification_level)]
-            if progression.num_verifies >= verification_info['goal']:
-                progression.verification_level += 1
-                progression.lobe_coins += verification_info['coin_reward']
-                progression.experience += \
-                    verification_info['experience_reward']
-                achievements.append('verification')
+            verification_levels = app.config['ECONOMY']['achievements'][
+                'verification'].keys()
+            if progression.verification_level in verification_levels:
+                verification_info = app.config['ECONOMY']['achievements'][
+                    'verification'][str(progression.verification_level)]
+                if progression.num_verifies >= verification_info['goal']:
+                    progression.verification_level += 1
+                    progression.lobe_coins += verification_info['coin_reward']
+                    progression.experience += \
+                        verification_info['experience_reward']
+                    achievements.append('verification')
+             else:
+                pass
             # 2. bad verifications
             spy_info = app.config['ECONOMY']['achievements']['spy'][
                 str(progression.spy_level)]


### PR DESCRIPTION
Upon completing level 5 in verification users get an error when attempting to verify.
According to the logs this is caused by the verification level check, in line 319-320 of lobe/views/verification/verification.py .
Checking whether the verification level the user has is indeed in the defined verification levels should stop the error from occurring. 
This may also occur for other achievements so adding it to the other checks in the future might be wise.